### PR TITLE
Open Issue if GitHub Actions workflows fail

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -68,3 +68,16 @@ jobs:
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/conda-forge-nightly-controller' && github.event_name != 'pull_request' }}
         run: bash ci/scripts/push-update.sh tiledb-py-feedstock
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: tiledb-py
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: "America/New_York"
+        run: bash scripts/open-issue.sh

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -56,3 +56,16 @@ jobs:
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/conda-forge-nightly-controller' && github.event_name != 'pull_request' }}
         run: bash ci/scripts/push-update.sh tiledb-feedstock
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: tiledb
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: "America/New_York"
+        run: bash scripts/open-issue.sh

--- a/scripts/open-issue.sh
+++ b/scripts/open-issue.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ex
+
+# Open new Issue (or comment on existing) after build failure
+
+if [[ -z "$GH_TOKEN" ]]
+then
+  echo "The env var GH_TOKEN is missing"
+  echo "Please define it as a GitHub PAT with write permissions to Issues"
+  exit 1
+fi
+
+theDate="$(date '+%A (%Y-%m-%d)')"
+theMessage="Nightly build failed for $GITHUB_WORKFLOW on $theDate in run [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+
+existing=$(gh issue list \
+  --label "nightly-failure" \
+  --limit 1 \
+  --jq '.[].number' \
+  --json "number" \
+  --state "open")
+
+if [[ -z "$existing" ]]
+then
+  # open new issue
+  gh issue create \
+    --assignee shaunrd0,ihnorton \
+    --body "$theMessage" \
+    --label "nightly-failure" \
+    --title "Nightly build failed on $theDate"
+else
+  # comment on existing issue
+  gh issue comment "$existing" \
+    --body "$theMessage"
+fi
+
+echo "Success!"


### PR DESCRIPTION
If one of the GitHub Actions workflows failed, open an Issue (or comment on existing open Issue)

To do prior to merge:

- [x] Manually create Issue label "nightly-failure"
- [x] Set default GitHub Actions token to be read-only. This is a personal preference for increased security. By default (at least in my personal repos), the default token has read and write access. I prefer to escalate permissions individually (eg `issues: write` as I use here)

Limitations:

* This uses the same Issue label for each recipe. Given that these workflows are largely tinkering with recipes, they are likely to fail for the same reasons. And even if not, the extra complexity of multiple labels doesn't seem worth it. I can add the complexity if requested

cc: @shaunrd0 ,@ihnorton 
xref: #1