### PR TITLE
Add scheduled workflow to simulate regular activity

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -1,0 +1,28 @@
+# GitHub automatically disables scheduled workflows if there has been no
+# activity in the repo in the last 60 days. This workflow pushes an empty commit
+# every month in order to (hopefully) prevent this
+# https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow
+name: activity
+on:
+  schedule:
+     # "At 00:00 on day-of-month 1."
+     # https://crontab.guru/#0_0_1_*_*
+     - cron: "0 0 1 * *"
+  workflow_dispatch:
+jobs:
+  commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "runneradmin@users.noreply.github.com"
+          git pull origin main
+      - name: Commit
+        run: git commit --allow-empty -m "Activity to enable GitHub Actions worfklows"
+      - name: Push
+        if: github.repository_owner == 'TileDB-Inc'
+        run: git push origin main


### PR DESCRIPTION
GitHub [automatically disables scheduled workflows](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow) if there has been no activity in the repo in the last 60 days. Obviously this policy isn't ideal for repos like this whose primary purpose is scheduling activity in other repos. This workflow pushes an empty commit every month in order to (hopefully) prevent this. I'm not 100% this will be sufficient activity, but it appears to be working in another repo I have that includes auto-commits from workflows.

cc: @shaunrd0 ,@ihnorton 
xref: #1