### PR TITLE
Delete old nightlies

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -1,7 +1,7 @@
 name: Delete old nightlies
 on:
   schedule:
-     - cron: "0 0 * * 1" # Every Monday
+     - cron: "36 0 * * 1" # Every Monday
   workflow_dispatch:
     inputs:
       TILEDB_CI_ACCOUNT:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -4,19 +4,19 @@ on:
      - cron: "0 0 * * 1" # Every Monday
   workflow_dispatch:
     inputs:
-      ACCOUNT:
+      TILEDB_CI_ACCOUNT:
         description: >-
           (string) The main account/channel on anaconda.org. The actual channel
-          to be searched will be "ACCOUNT/label/nightlies"
+          to be searched will be "TILEDB_CI_ACCOUNT/label/nightlies"
         required: true
         default: "tiledb"
-      DAYS:
+      TILEDB_CI_DAYS:
         description: >-
           (integer) Number of days to keep nightlies (ie nightlies uploaded more
-          than $DAYS days ago will be removed)
+          than $TILEDB_CI_DAYS days ago will be removed)
         required: true
         default: 7
-      DRY_RUN:
+      TILEDB_CI_DRY_RUN:
         description: >-
           (integer) Exit without actually removing packages. Default is 0. Set
           to 1 for dry run
@@ -25,9 +25,9 @@ defaults:
   run:
     shell: bash -l {0}
 env:
-  ACCOUNT: ${{ github.event.inputs.ACCOUNT || 'tiledb' }}
-  DAYS: ${{ github.event.inputs.DAYS || 7 }}
-  DRY_RUN: ${{ github.event.inputs.DRY_RUN || 0 }}
+  TILEDB_CI_ACCOUNT: ${{ github.event.inputs.TILEDB_CI_ACCOUNT || 'tiledb' }}
+  TILEDB_CI_DAYS: ${{ github.event.inputs.TILEDB_CI_DAYS || 7 }}
+  TILEDB_CI_DRY_RUN: ${{ github.event.inputs.TILEDB_CI_DRY_RUN || 0 }}
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
 jobs:
   remove:
@@ -45,6 +45,6 @@ jobs:
         run: |
           for subdir in linux-64 linux-aarch64 linux-ppc64le osx-64 osx-arm64 win-64
           do
-            SUBDIR="$subdir" bash scripts/delete-old-nightlies.sh
+            TILEDB_CI_SUBDIR="$subdir" bash scripts/delete-old-nightlies.sh
             sleep 1
           done

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -1,0 +1,50 @@
+name: Delete old nightlies
+on:
+  schedule:
+     - cron: "0 0 * * 1" # Every Monday
+  workflow_dispatch:
+    inputs:
+      ACCOUNT:
+        description: >-
+          (string) The main account/channel on anaconda.org. The actual channel
+          to be searched will be "ACCOUNT/label/nightlies"
+        required: true
+        default: "tiledb"
+      DAYS:
+        description: >-
+          (integer) Number of days to keep nightlies (ie nightlies uploaded more
+          than $DAYS days ago will be removed)
+        required: true
+        default: 7
+      DRY_RUN:
+        description: >-
+          (integer) Exit without actually removing packages. Default is 0. Set
+          to 1 for dry run
+        default: 0
+defaults:
+  run:
+    shell: bash -l {0}
+env:
+  ACCOUNT: ${{ github.event.inputs.ACCOUNT || 'tiledb' }}
+  DAYS: ${{ github.event.inputs.DAYS || 7 }}
+  DRY_RUN: ${{ github.event.inputs.DRY_RUN || 0 }}
+  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+jobs:
+  remove:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup conda env
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: scripts/delete-old-nightlies.yml
+          cache-env: true
+      - name: Confirm anaconda.org API token is valid
+        run: anaconda --token "$ANACONDA_TOKEN" whoami
+      - name: Remove old nightlies
+        run: |
+          for subdir in linux-64 linux-aarch64 linux-ppc64le osx-64 osx-arm64 win-64
+          do
+            SUBDIR="$subdir" bash scripts/delete-old-nightlies.sh
+            sleep 1
+          done

--- a/scripts/delete-old-nightlies.sh
+++ b/scripts/delete-old-nightlies.sh
@@ -4,36 +4,36 @@ set -euo pipefail
 #
 # Usage:
 #   export ANACONDA_TOKEN="<api-token>"
-#   ACCOUNT=tiledb DAYS=7 scripts/delete-old-nightlies.sh
+#   TILEDB_CI_ACCOUNT=tiledb TILEDB_CI_DAYS=7 scripts/delete-old-nightlies.sh
 #
 # Variables that must be defined outside of this script:
 #
 # ANACONDA_TOKEN: (string) API token for anaconda.org
-# ACCOUNT: (string) The main account/channel on anaconda.org. The actual channel
-#          to be searched will be "ACCOUNT/label/nightlies"
-# DAYS: (integer) Number of days to keep nightlies (ie nightlies uploaded more
-#       than $DAYS days ago will be removed)
+# TILEDB_CI_ACCOUNT: (string) The main account/channel on anaconda.org. The actual channel
+#          to be searched will be "TILEDB_CI_ACCOUNT/label/nightlies"
+# TILEDB_CI_DAYS: (integer) Number of days to keep nightlies (ie nightlies uploaded more
+#       than $TILEDB_CI_DAYS days ago will be removed)
 #
 # Variables that can be defined outside of this script:
 #
-# SUBDIR: linux-64 (default), linux-aarch64, linux-ppc64le, osx-64, osx-arm64, win-64
-# DRY_RUN: (integer) Exit without actually removing packages. Default is 0. Set
+# TILEDB_CI_SUBDIR: linux-64 (default), linux-aarch64, linux-ppc64le, osx-64, osx-arm64, win-64
+# TILEDB_CI_DRY_RUN: (integer) Exit without actually removing packages. Default is 0. Set
 #          to 1 for dry run
 
 # optional variables
-SUBDIR="${SUBDIR:-linux-64}"
-DRY_RUN="${DRY_RUN:-0}"
+TILEDB_CI_SUBDIR="${TILEDB_CI_SUBDIR:-linux-64}"
+TILEDB_CI_DRY_RUN="${TILEDB_CI_DRY_RUN:-0}"
 
-channel="$ACCOUNT/label/nightlies"
-echo "Removing $SUBDIR nightlies more than $DAYS days old from the channel $channel"
+channel="$TILEDB_CI_ACCOUNT/label/nightlies"
+echo "Removing $TILEDB_CI_SUBDIR nightlies more than $TILEDB_CI_DAYS days old from the channel $channel"
 
-conda search -v --json --override-channels -c "$channel" --subdir "$SUBDIR" > nightlies.json
+conda search -v --json --override-channels -c "$channel" --subdir "$TILEDB_CI_SUBDIR" > nightlies.json
 
 total=$(jq 'flatten | length' nightlies.json)
 echo "Total nightlies: $total"
 
 # in milliseconds since the epoch
-cutoff=$(expr $(date --date="$DAYS days ago" +%s) \* 1000)
+cutoff=$(expr $(date --date="$TILEDB_CI_DAYS days ago" +%s) \* 1000)
 
 jq -r --argjson cutoff $cutoff \
   'flatten | .[] | select(.timestamp < $cutoff) | .name + "/" + .version + "/" + .subdir + "/" + .fn' \
@@ -42,7 +42,7 @@ jq -r --argjson cutoff $cutoff \
 total_to_be_removed=$(cat nightlies-to-remove.txt | wc -l)
 echo "Total to be removed: $total_to_be_removed"
 
-if [[ "$DRY_RUN" -eq 1 ]]
+if [[ "$TILEDB_CI_DRY_RUN" -eq 1 ]]
 then
   echo "Dry run: exit early"
   exit 0
@@ -52,7 +52,7 @@ fi
 
 for nightly in `cat nightlies-to-remove.txt`
 do
-  echo "$ACCOUNT/$nightly"
-  anaconda --token "$ANACONDA_TOKEN" remove --force "$ACCOUNT/$nightly"
+  echo "$TILEDB_CI_ACCOUNT/$nightly"
+  anaconda --token "$ANACONDA_TOKEN" remove --force "$TILEDB_CI_ACCOUNT/$nightly"
   sleep 0.1
 done

--- a/scripts/delete-old-nightlies.sh
+++ b/scripts/delete-old-nightlies.sh
@@ -1,0 +1,58 @@
+set -euo pipefail
+
+# Search for and delete old nightlies
+#
+# Usage:
+#   export ANACONDA_TOKEN="<api-token>"
+#   ACCOUNT=tiledb DAYS=7 scripts/delete-old-nightlies.sh
+#
+# Variables that must be defined outside of this script:
+#
+# ANACONDA_TOKEN: (string) API token for anaconda.org
+# ACCOUNT: (string) The main account/channel on anaconda.org. The actual channel
+#          to be searched will be "ACCOUNT/label/nightlies"
+# DAYS: (integer) Number of days to keep nightlies (ie nightlies uploaded more
+#       than $DAYS days ago will be removed)
+#
+# Variables that can be defined outside of this script:
+#
+# SUBDIR: linux-64 (default), linux-aarch64, linux-ppc64le, osx-64, osx-arm64, win-64
+# DRY_RUN: (integer) Exit without actually removing packages. Default is 0. Set
+#          to 1 for dry run
+
+# optional variables
+SUBDIR="${SUBDIR:-linux-64}"
+DRY_RUN="${DRY_RUN:-0}"
+
+channel="$ACCOUNT/label/nightlies"
+echo "Removing $SUBDIR nightlies more than $DAYS days old from the channel $channel"
+
+conda search -v --json --override-channels -c "$channel" --subdir "$SUBDIR" > nightlies.json
+
+total=$(jq 'flatten | length' nightlies.json)
+echo "Total nightlies: $total"
+
+# in milliseconds since the epoch
+cutoff=$(expr $(date --date="$DAYS days ago" +%s) \* 1000)
+
+jq -r --argjson cutoff $cutoff \
+  'flatten | .[] | select(.timestamp < $cutoff) | .name + "/" + .version + "/" + .subdir + "/" + .fn' \
+  nightlies.json > nightlies-to-remove.txt
+
+total_to_be_removed=$(cat nightlies-to-remove.txt | wc -l)
+echo "Total to be removed: $total_to_be_removed"
+
+if [[ "$DRY_RUN" -eq 1 ]]
+then
+  echo "Dry run: exit early"
+  exit 0
+else
+  echo "Removing packages"
+fi
+
+for nightly in `cat nightlies-to-remove.txt`
+do
+  echo "$ACCOUNT/$nightly"
+  anaconda --token "$ANACONDA_TOKEN" remove --force "$ACCOUNT/$nightly"
+  sleep 0.1
+done

--- a/scripts/delete-old-nightlies.yml
+++ b/scripts/delete-old-nightlies.yml
@@ -1,0 +1,8 @@
+name: delete-old-nightlies
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - anaconda-client
+  - bash
+  - jq


### PR DESCRIPTION
This GitHub Actions pipelines deletes old nightlies. It is set to run every Monday and remove all nightlies that were uploaded more than 7 days ago

Closes #5 

cc: @ihnorton @Shelnutt2

## Setup steps

The following setup steps are required:

1. Go to https://anaconda.org/tiledb/settings/access and create a new API token with scope "Allow all API operations"
1. Create a [new repository secret](https://github.com/TileDB-Inc/conda-forge-nightly-controller/settings/secrets/actions) named `ANACONDA_TOKEN` and copy-paste the token

## Execution

The script can be run locally, eg:

```sh
mamba env create --file scripts/delete-old-nightlies.yml
mamba activate delete-old-nightlies
export ANACONDA_TOKEN="<api-token>"
ACCOUNT=tiledb DAYS=7 SUBDIR=osx-arm64 scripts/delete-old-nightlies.sh
```

Or executed remotely using the `workflow_dispatch` trigger:

![image](https://user-images.githubusercontent.com/1608317/226717849-3e17e58a-f5ce-4d53-8ca5-39a0eca82752.png)

## Example

On my fork, I used the `workflow_dispatch` trigger to delete all the nightlies from my account that were uploaded more than 140 days ago.

```sh
date --date="140 days ago"
## Tue Nov  1 15:03:38 EDT 2022
```

As can be seen in the [build log](https://github.com/jdblischak/conda-forge-nightly-controller/actions/runs/4482850391/jobs/7881415269#step:5:287), all the nightlies from October were deleted. And the only nightlies remaining in my account are from [November](https://anaconda.org/jdblischak/tiledb/files) (note that in a previous run I deleted all the linux-64 and osx-64 nightlies, which is why their November nightlies aren't there; also, for context, I stopped uploading nightlies to my channel in November when this repo was created)