### PR TITLE
Exit early if a subdir has no nightlies to delete

### DIFF
--- a/scripts/delete-old-nightlies.sh
+++ b/scripts/delete-old-nightlies.sh
@@ -27,7 +27,9 @@ TILEDB_CI_DRY_RUN="${TILEDB_CI_DRY_RUN:-0}"
 channel="$TILEDB_CI_ACCOUNT/label/nightlies"
 echo "Removing $TILEDB_CI_SUBDIR nightlies more than $TILEDB_CI_DAYS days old from the channel $channel"
 
-conda search -v --json --override-channels -c "$channel" --subdir "$TILEDB_CI_SUBDIR" > nightlies.json
+conda search -v --json --override-channels -c "$channel" \
+  --subdir "$TILEDB_CI_SUBDIR" > nightlies.json || \
+  { echo "Total nightlies: 0" && exit 0; }
 
 total=$(jq 'flatten | length' nightlies.json)
 echo "Total nightlies: $total"


### PR DESCRIPTION
Because the libtiledb nightlies have been failing (#7), there are currently no nightlies in the subdir linux-ppc64le. When `conda search` is unable to find any packages, it fails with exit code 1, causing the entire script to fail. This PR fixes the problem using `||` and exiting early if a subdir contains no nightlies to delete.