### PR TITLE
Add pull_request trigger for testing with authentication

### DIFF
--- a/.github/workflows/linux-py37.yml
+++ b/.github/workflows/linux-py37.yml
@@ -2,6 +2,7 @@
 # Required to support TileDB Cloud UDFs until service agreement expires
 name: linux-py37
 on:
+  pull_request:
   schedule:
      # "At minute 23 past hour 0, 6, 12, and 18."
      # https://crontab.guru/#23_0,6,12,18_*_*_*
@@ -31,5 +32,5 @@ jobs:
         run: |
           git commit -a -m "Update recipe" || echo "nothing to commit"
       - name: Push
-        if: github.repository_owner == 'TileDB-Inc'
+        if: github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'
         run: git push origin build-linux-64-py37

--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -1,5 +1,6 @@
 name: tiledb-py
 on:
+  pull_request:
   # This job depends on a previous passing run of TileDB conda nightly.
   # Schedule for conda nightly against TileDB-Py should begin after TileDB core.
   schedule:

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -1,5 +1,6 @@
 name: tiledb
 on:
+  pull_request:
   schedule:
      - cron: "0 1 * * *" # Every night at 1 AM UTC (8 PM EST; 9 PM EDT)
   workflow_dispatch:


### PR DESCRIPTION
Motivation: to test as much workflow logic as possible in pull requests without actually kicking off the nightly builds

* This will prevent a situation like #11 and #12 where a syntax error in a GitHub Action prevented the nightly builds. I couldn't test this in my fork because I don't have the required SSH keys
* By specifying `github.event_name != 'pull_request'`, I prevent any push to the "nightly-build" branches
* However, note that this will result in the "main" branch in the TileDB-Inc fork of a feedstock being updated if any commits had been merged into the upstream conda-forge repo since the night before. This isn't a problem since it doesn't trigger any nightly builds
* I didn't add a `pull_request` trigger to the "Delete old nightlies" workflow. It would take some creativity to set it to dry run mode when triggered by a PR, and I've already added an anaconda token to my fork to facilitate testing, so this isn't worth the effort