### PR TITLE
Always update conda-smithy for nightly job

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -49,6 +49,9 @@ jobs:
             setuptools-scm
             wheel
           cache-environment: true
+      - name: Update conda-smithy
+        shell: bash -l {0}
+        run: micromamba update --yes conda-smithy
       - name: Obtain version from setup.py
         shell: bash -l {0}
         run: bash ci/scripts/tiledb-py/obtain-version.sh

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -48,6 +48,9 @@ jobs:
           environment-name: env
           create-args: conda-smithy
           cache-environment: true
+      - name: Update conda-smithy
+        shell: bash -l {0}
+        run: micromamba update --yes conda-smithy
       - name: Rerender feedstock
         shell: bash -l {0}
         run: bash ci/scripts/rerender-feedstock.sh tiledb-feedstock


### PR DESCRIPTION
conda-smithy checks if it is the latest version available, and since the job caches the conda env, it fails to rerender the feedstock every time there is a new conda-smithy release

Closes #18 

xref: #16 