### PR TITLE
Add John B to assignee list for nightly failures

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -87,6 +87,6 @@ jobs:
         with:
           name: nightly build
           label: nightly-failure
-          assignee: shaunrd0,KiterLuc,ihnorton
+          assignee: shaunrd0,KiterLuc,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -70,6 +70,6 @@ jobs:
         with:
           name: nightly build
           label: nightly-failure
-          assignee: shaunrd0,KiterLuc,ihnorton
+          assignee: shaunrd0,KiterLuc,ihnorton,jdblischak
         env:
           TZ: "America/New_York"


### PR DESCRIPTION
When I originally wrote this GitHub workflow, I didn't have write-access to this repo. Now that I do, I can also be assigned to nightly failure issues