### PR TITLE
Can't use py312 with anaconda-client bc it removed `imp`

### DIFF
--- a/scripts/delete-old-nightlies.yml
+++ b/scripts/delete-old-nightlies.yml
@@ -6,3 +6,7 @@ dependencies:
   - anaconda-client
   - bash
   - jq
+  # Python 3.12 removed the module `imp`, which is used
+  # by the Anaconda package `clyent`
+  # https://docs.python.org/3.12/whatsnew/3.12.html#imp
+  - python<3.12


### PR DESCRIPTION
The delete-old-nightlies job has been failing for more than a month (Oct 15th)

https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/6527617948/job/17722694223#step:4:13

```python
anaconda --token "$ANACONDA_TOKEN" whoami

  File "/home/runner/micromamba/envs/delete-old-nightlies/bin/anaconda", line 6, in <module>
    from binstar_client.scripts.cli import main
  File "/home/runner/micromamba/envs/delete-old-nightlies/lib/python3.12/site-packages/binstar_client/__init__.py", line 19, in <module>
    from . import errors
  File "/home/runner/micromamba/envs/delete-old-nightlies/lib/python3.12/site-packages/binstar_client/errors.py", line 3, in <module>
    from clyent.errors import ClyentError
  File "/home/runner/micromamba/envs/delete-old-nightlies/lib/python3.12/site-packages/clyent/__init__.py", line 5, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
```

The problem is that Python 3.12 removed `imp`, which is used by a dependency of anaconda-client

https://docs.python.org/3.12/whatsnew/3.12.html#imp

I pushed directly upstream to be able to test with token. First did a dry run to confirm the fix. Then ran it for real to delete the old nightlies

* [dry run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/7006845216/job/19059613508)
* [deleted backlog of nightlies](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/7006901206/job/19059791591)

