### PR TITLE
Open an Issue when any scheduled workflow fails

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -26,3 +26,19 @@ jobs:
       - name: Push
         if: github.repository_owner == 'TileDB-Inc'
         run: git push origin main
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: commit
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: activity
+          label: bug
+          assignee: shaunrd0,ihnorton,jdblischak
+        env:
+          TZ: "America/New_York"

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -48,3 +48,19 @@ jobs:
             TILEDB_CI_SUBDIR="$subdir" bash scripts/delete-old-nightlies.sh
             sleep 1
           done
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: remove
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: delete old nightlies
+          label: bug
+          assignee: shaunrd0,ihnorton,jdblischak
+        env:
+          TZ: "America/New_York"

--- a/.github/workflows/linux-py37.yml
+++ b/.github/workflows/linux-py37.yml
@@ -33,3 +33,19 @@ jobs:
       - name: Push
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'
         run: git push origin build-linux-64-py37
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: update-recipe
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: py37 linux
+          label: bug
+          assignee: shaunrd0,ihnorton,jdblischak
+        env:
+          TZ: "America/New_York"


### PR DESCRIPTION
I don't get a notification when a GitHub workflow job fails in the TileDB-Inc org (I do for repos I own in my account). This PR updates all the workflows to open an Issue on failure. Since these failures don't indicate anything wrong with the nightly builds, I used the generic, existing label `bug`. I also removed Luc since he only has to be notified for potential problems with libtiledb.