### PR TITLE
Use unique labels to distinguish Issues for each pipeline

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -38,7 +38,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: activity
-          label: bug
+          label: bug,scheduled,activity
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/check-azure-status.yml
+++ b/.github/workflows/check-azure-status.yml
@@ -44,7 +44,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: azure status check
-          label: bug
+          label: bug,scheduled,check-azure-status
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -60,7 +60,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: delete old nightlies
-          label: bug
+          label: bug,scheduled,delete-old-nightlies
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/linux-py37.yml
+++ b/.github/workflows/linux-py37.yml
@@ -45,7 +45,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: py37 linux
-          label: bug
+          label: bug,scheduled,linux-py37
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -86,7 +86,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: nightly TileDB-Py setup
-          label: bug
+          label: bug,scheduled,tiledb-py
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -69,7 +69,7 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: nightly TileDB setup
-          label: bug
+          label: bug,scheduled,tiledb
           assignee: shaunrd0,ihnorton,jdblischak
         env:
           TZ: "America/New_York"


### PR DESCRIPTION
I realized that by using the same label, `bug`, for Issues opened by failures of any of the pipelines would result in every pipeline writing to the same open Issue (since the `open-issue` action uses the label(s) to determine if it should open a new Issue or comment on an existing one).

I created a new label `scheduled` as well as one for each of the 6 pipelines ([labels](https://github.com/TileDB-Inc/conda-forge-nightly-controller/labels)). Thus an automated Issue opened by a failed workflow will have the labels `bug`, `scheduled`, and `<name-of-workflow>`. This allows a developer to still manually open an Issue with the labels `bug` and `<name-of-workflow>` to document a bug that needs fixed