### PR TITLE
Check Azure status in serial to avoid duplicate Issues

### DIFF
--- a/.github/workflows/check-azure-status.yml
+++ b/.github/workflows/check-azure-status.yml
@@ -22,6 +22,7 @@ jobs:
   tiledb-py-feedstock:
     # https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=5&branchName=nightly-build
     runs-on: ubuntu-latest
+    needs: tiledb-feedstock
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
Currently the azure status checks run in parallel. In the case where both tiledb-feedstock and tiledb-py-feedstock fail their nightly builds, this can result in two Issues being opened, eg #44 and #45. However, when tiledb-feedstock fails, this will always cause tiledb-py-feedstock to fail. Thus one Issue is preferred.

This PR updates the Azure status checks to run serially, so that the tiledb-py-feedstock failure will append to the new Issue instead of opening an independent one.