### PR TITLE
Revert "Add libboost-devel to libtiledb nightly recipe for 2.21"

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,10 +23,5 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
-# (temporary) Add libboost-devel for 2.21
-sed -i \
-  s/host:/'host:\n    - libboost-devel'/ \
-  tiledb-feedstock/recipe/meta.yaml
-
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Reverts TileDB-Inc/conda-forge-nightly-controller#50

TileDB has removed the dependency to Boost (TileDB-Inc/TileDB#4731).