### PR TITLE
Prevent unnecessary rerendering failures when conda-smithy is updated

### DIFF
--- a/scripts/rerender-feedstock.sh
+++ b/scripts/rerender-feedstock.sh
@@ -3,4 +3,4 @@ set -eux
 
 repo="$1"
 
-conda smithy rerender --commit auto --feedstock_directory "$repo"
+conda smithy rerender --no-check-uptodate --commit auto --feedstock_directory "$repo"


### PR DESCRIPTION
Closes #55 #56 

conda-smithy 3.31.0 was marked as broken and 3.31.1 hasn't been merged yet

https://github.com/conda-forge/conda-smithy-feedstock/pull/278
https://github.com/conda-forge/conda-smithy-feedstock/pull/279
https://github.com/conda-forge/conda-smithy/issues/1847
https://github.com/conda-forge/conda-smithy/issues/1848