### PR TITLE
Install jsonschema for conda-smithy v3.32.0

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -41,6 +41,7 @@ jobs:
             conda-smithy
             cmake
             cython
+            jsonschema
             numpy
             pybind11
             ruamel.yaml

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -46,7 +46,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: env
-          create-args: conda-smithy
+          create-args: conda-smithy jsonschema
           cache-environment: true
       - name: Update conda-smithy
         shell: bash -l {0}


### PR DESCRIPTION
Closes #64 and #65

Caused by https://github.com/conda-forge/conda-smithy/issues/1866

Successful runs in branches (that don't push to feedstock): [TileDB](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/8300518088), [TileDB-Py](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/8300519257)