### PR TITLE
Do not open Issue for failed Azure nightly build on a fork

### DIFF
--- a/.github/workflows/check-azure-status.yml
+++ b/.github/workflows/check-azure-status.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Azure Status API
+        if: github.repository_owner == 'TileDB-Inc' # do not run on forks
         env:
           GH_TOKEN: ${{ github.token }}
         run:  bash scripts/check-azure-status.sh 4 tiledbfeedstock_CI


### PR DESCRIPTION
Companion to https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/104

I hadn't realized this would create unnecessary noise on forks because I have disabled Actions on my fork of conda-forge-nightly-controller.