### PR TITLE
Commit all edited and new files for nightly builds

### DIFF
--- a/scripts/add-and-commit.sh
+++ b/scripts/add-and-commit.sh
@@ -7,5 +7,5 @@ version="$(cat version.txt)$(cat date.txt)"
 git -C "$repo" config --local user.name "GitHub Actions"
 git -C "$repo" config --local user.email "runneradmin@github.com"
 git -C "$repo" checkout --quiet -B nightly-build main
-git -C "$repo" add conda-forge.yml recipe/conda_build_config.yaml recipe/meta.yaml
+git -C "$repo" add .
 git -C "$repo" commit --quiet -m "Nightly build for $version"


### PR DESCRIPTION
Follow-up to #71. Last night's [nightly build](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=38658&view=results) added azure-identity-cpp to the host requirements but didn't include the empty overlay port for vcpkg ([commit](https://github.com/TileDB-Inc/tiledb-feedstock/commit/0f977ab5551f665d338bb6a93b6134b37362a19d)), so it was built with vcpkg instead of relying on the conda-installed one:

```
     azure-identity-cpp:x64-linux -> 1.6.0 -- $SRC_DIR/build/_deps/vcpkg-src/buildtrees/versioning_/versions/azure-identity-cpp/cb43628d1a08baa198ed4cdc7d317ed73ed3815f
```

This PR updates the scripts to commit any changes made to the feedstock repository (including new files), so that any potential future fixes will automatically be committed.

xref: #69 
