### PR TITLE
Set c_stdlib_version to match Windows compiler

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -40,6 +40,8 @@ c_compiler:    # [win]
   - vs2022       # [win]
 cxx_compiler:  # [win]
   - vs2022       # [win]
+c_stdlib_version:    # [win]
+  - 2022             # [win]
 EOF
 
 


### PR DESCRIPTION
Closes #86 

xref: follow-up to #74

We previously bumped the Windows compiler to vs2022. However, due to recent changes in the conda-forge ecosystem (they've added a new pin for the C standard library), we need to also pin `c_stdlib_version` to 2022.

I confirmed this fixes the build by pushing directly to the [nightly-build](https://github.com/TileDB-Inc/tiledb-feedstock/commits/nightly-build/) branch. Below are the relevant commits and CI (note that the commits will be overwritten by tonight's nightly, but the links to specific commits should continue to work)

https://github.com/TileDB-Inc/tiledb-feedstock/commit/52cebe41d1d4e93d03a245769cb66e4d2fb86e7f
https://github.com/TileDB-Inc/tiledb-feedstock/commit/a40b10ccdfd3ce7406c87d1b2c5a75b5a3963d20
https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=38951&view=results