### PR TITLE
Update actions to Node 20

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup
         run: |
           git config user.name "GitHub Actions"
@@ -33,7 +33,7 @@ jobs:
     needs: commit
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/check-azure-status.yml
+++ b/.github/workflows/check-azure-status.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Azure Status API
         if: github.repository_owner == 'TileDB-Inc' # do not run on forks
         env:
@@ -27,7 +27,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Azure Status API
         if: github.repository_owner == 'TileDB-Inc' # do not run on forks
         env:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -33,7 +33,7 @@ jobs:
   remove:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup conda env
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -55,7 +55,7 @@ jobs:
     needs: remove
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -13,19 +13,19 @@ jobs:
       TZ: "America/New_York"
     steps:
       - name: Clone nightlies CI repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/conda-forge-nightly-controller
           path: ci
       - name: Clone feedstock
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/tiledb-py-feedstock
           ref: main
           path: tiledb-py-feedstock
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY_TILEDB_PY }}
       - name: Clone source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/TileDB-Py
           ref: dev
@@ -82,7 +82,7 @@ jobs:
     needs: tiledb-py
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -11,19 +11,19 @@ jobs:
       TZ: "America/New_York"
     steps:
       - name: Clone nightlies CI repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/conda-forge-nightly-controller
           path: ci
       - name: Clone feedstock
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/tiledb-feedstock
           ref: main
           path: tiledb-feedstock
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY_TILEDB }}
       - name: Clone source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/TileDB
           ref: dev
@@ -64,7 +64,7 @@ jobs:
     needs: tiledb
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:


### PR DESCRIPTION
GitHub is deprecating Node 16 actions. Starting in June they will require opting-in to Node 16 by specifying an env var in the worfklow file.

https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
