### PR TITLE
Revert "Remove temporary pr-4995.patch (#99)".

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,9 +23,5 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
-# (temporary) Remove pr-4995.patch
-git -C tiledb-feedstock/ rm recipe/pr-4995.patch
-sed -i /4995/d tiledb-feedstock/recipe/meta.yaml
-
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
 Closes #100

This reverts commit 2cd189f4a5048d5e3281ed49090631dcf852ca21.

Needs to be merged after 2.24.0 update PR is merged upstream in https://github.com/conda-forge/tiledb-feedstock/pull/295