### PR TITLE
Remove lz4-fix.patch

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,5 +23,9 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
+# (temporary) Remove lz4-fix.patch
+git rm tiledb-feedstock/recipe/lz4-fix.patch
+sed -i /lz4-fix.patch/d tiledb-feedstock/recipe/meta.yaml
+
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Due to upstream changes, the `lz4-fix.patch` can no longer be applied. Until the next feedstock update, we have to remove this for the nightly builds.

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/108#issuecomment-2236234946, #99

Note that this is currently the only remaining patch, which means that the `patches:` field in the recipe YAML will be empty. I confirmed on my fork that this doesn't cause a problem ([commit](https://github.com/jdblischak/tiledb-feedstock/commit/8b209013423d9e7b7880c6285863ae9a4bc835d5), [build](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=889&view=results))