### PR TITLE
Fix patch removal code from #110

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -24,7 +24,7 @@ sed -i \
   tiledb-feedstock/recipe/meta.yaml
 
 # (temporary) Remove lz4-fix.patch
-git rm tiledb-feedstock/recipe/lz4-fix.patch
+git -C tiledb-feedstock/ rm recipe/lz4-fix.patch
 sed -i /lz4-fix.patch/d tiledb-feedstock/recipe/meta.yaml
 
 # Print differences


### PR DESCRIPTION
I copied the code for #110 from #99, and thus of course made the exact same mistake that I had to fix last time in #103

I confirmed via a [manual run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10012244974) of my internal branch (required to have SSH keys) that the patch is deleted.