### PR TITLE
Migrate tiledb-py-feedstock to scikit-build-core

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Update conda-smithy
         shell: bash -l {0}
         run: micromamba update --yes conda-smithy
-      - name: Obtain version from setup.py
+      - name: Obtain version
         shell: bash -l {0}
         run: bash ci/scripts/tiledb-py/obtain-version.sh
       - name: Obtain commit
@@ -64,7 +64,7 @@ jobs:
         shell: bash -l {0}
         run: python ci/scripts/tiledb-py/update-recipe.py
       - name: Print recipe diff
-        run: git -C tiledb-py-feedstock/ --no-pager diff recipe/meta.yaml
+        run: git -C tiledb-py-feedstock/ --no-pager diff recipe/
       - name: Update channels
         run: bash ci/scripts/update-channels.sh tiledb-py-feedstock
       - name: Add and commit

--- a/run-local-tiledb-py.sh
+++ b/run-local-tiledb-py.sh
@@ -37,6 +37,8 @@ else
     cython \
     numpy \
     pybind11 \
+    ruamel.yaml \
+    ruamel.yaml.jinja2 \
     setuptools \
     setuptools-scm \
     wheel
@@ -47,7 +49,7 @@ mamba update --yes --quiet conda-smithy
 bash scripts/tiledb-py/obtain-version.sh
 bash scripts/obtain-commit.sh TileDB-Py
 bash scripts/pull-upstream-feedstock.sh tiledb-py-feedstock
-bash scripts/tiledb-py/update-recipe.sh
+python scripts/tiledb-py/update-recipe.py
 bash scripts/update-channels.sh tiledb-py-feedstock
 bash scripts/add-and-commit.sh tiledb-py-feedstock
 

--- a/scripts/tiledb-py/obtain-version.sh
+++ b/scripts/tiledb-py/obtain-version.sh
@@ -2,6 +2,6 @@
 set -eux
 
 cd TileDB-Py
-python setup.py --version | tail -n 1 > ../version.txt
+git tag --sort=-committerdate | head -n 1 > ../version.txt
 cd -
 cat version.txt

--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -54,5 +54,17 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb *.%s" % (date)
 
+# (Temporary) Add requirements for scikit-build-core
+updated["requirements"]["build"].append("make")
+updated["requirements"]["build"].append("cmake")
+updated["requirements"]["host"].append("scikit-build-core")
+
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
+
+# (Temporary) Update build scripts for scikit-build-core
+with open("tiledb-py-feedstock/recipe/build.sh", "w") as f:
+    f.write("TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .")
+
+with open("tiledb-py-feedstock/recipe/bld.bat", "w") as f:
+    f.write("set \"TILEDB_PATH=${PREFIX}\" && {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .")

--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -28,4 +28,4 @@ git -C tiledb-feedstock/ rm recipe/lz4-fix.patch
 sed -i /lz4-fix.patch/d tiledb-feedstock/recipe/meta.yaml
 
 # Print differences
-git -C tiledb-feedstock/ --no-pager diff recipe/meta.yaml
+git -C tiledb-feedstock/ --no-pager diff recipe/


### PR DESCRIPTION
Upstream TileDB-Py has been migrated to scikit-build-core (https://github.com/TileDB-Inc/TileDB-Py/pull/1988). I applied the changes in https://github.com/conda-forge/tiledb-py-feedstock/pull/224 to the nightly feedstock build.

I verified both locally with `run-local-tiledb-py.sh` and via a [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10046546164/job/27766225652#step:12:1) on an internal branch.

```sh
git -C tiledb-py-feedstock/ --no-pager diff recipe/

diff --git a/recipe/bld.bat b/recipe/bld.bat
index 60fd47[9](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10046546164/job/27766225652#step:12:10)..ecc81ff 100644
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1 @@
-set TILEDB_CONDA_BUILD=1
-
-"%PYTHON%" setup.py build_ext --tiledb=%LIBRARY_PREFIX% ^
-           install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1
+set "TILEDB_PATH=${PREFIX}" && {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/build.sh b/recipe/build.sh
index 157dbd6..1f7ff59 [10](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10046546164/job/27766225652#step:12:11)0644
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1 @@
-#!/bin/bash
-
-set -e
-set -x
-
-export TILEDB_CONDA_BUILD=1
-
-$PYTHON setup.py install --tiledb="$PREFIX" --single-version-externally-managed --record record.txt
+TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 4a329d6..6ed6903 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,15 @@
-{% set name = "tiledb" %}
-{% set version = "0.30.2" %}
-{% set sha256 = "8a70e62b1cea6a1bba8afb1d36a635e9c5435db733944fb4e6d7493fa1d914a3" %}
-
+# nightly build
 package:
   name: tiledb-py
-  version: {{ version }}
+  version: 0.30.2.2024_07_22
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-
+  git_url: https://github.com/TileDB-Inc/TileDB-Py.git
+  git_rev: c506394827ae8eadd7ad021dd007022406516c19
+  git_depth: -1
 build:
   number: 0
   skip: true  # [win32]
-  skip: true  # [win and py2k]
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -24,6 +19,8 @@ requirements:
     - cython <3.0                            # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
     - pybind[11](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10046546164/job/27766225652#step:12:12)                               # [build_platform != target_platform]
+    - make
+    - cmake
   host:
     - pip
     - wheel
@@ -33,7 +30,8 @@ requirements:
     - cython <3.0
     - numpy
     - pybind11
-    - tiledb >=2.24.0,<2.25
+    - tiledb *.2024_07_22
+    - scikit-build-core
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -62,7 +60,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Python interface to the TileDB sparse and dense multi-dimensional array storage manager
+  summary: Python interface to the TileDB sparse and dense multi-dimensional array
+    storage manager
   description: |
     TileDB-Py is the python interface to the TileDB array storage manager.
     TileDB  is an efficient multi-dimensional array management system which introduces
```