### PR TITLE
Use env vars in build scripts for scikit-build-core migration

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -64,7 +64,7 @@ with open(recipe, "w") as f:
 
 # (Temporary) Update build scripts for scikit-build-core
 with open("tiledb-py-feedstock/recipe/build.sh", "w") as f:
-    f.write("TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .")
+    f.write("TILEDB_PATH=${PREFIX} ${PYTHON} -m pip install --no-build-isolation --no-deps --ignore-installed -v .")
 
 with open("tiledb-py-feedstock/recipe/bld.bat", "w") as f:
-    f.write("set \"TILEDB_PATH=${PREFIX}\" && {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .")
+    f.write("set \"TILEDB_PATH=%LIBRARY_PREFIX%\" && %PYTHON% -m pip install --no-build-isolation --no-deps --ignore-installed -v .")


### PR DESCRIPTION
In #114, I copied the jinja2 syntax from https://github.com/conda-forge/tiledb-py-feedstock/pull/224 into the build scripts (it was easier to use separate build scripts than to try and use separate `script` YAML fields with jinja2 preprocessing selectors). This broke the nightly feedstock builds (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/108#issuecomment-2245528288). This PR updates the build scripts to use environment variables.

I tested locally and from an [internal branch](https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/108#issuecomment-2245528288).

```diff
Run git -C tiledb-py-feedstock/ --no-pager diff recipe/

diff --git a/recipe/bld.bat b/recipe/bld.bat
index 60fd47[9](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10061640917/job/27812196459#step:12:10)..500f2b0 100644
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1 @@
-set TILEDB_CONDA_BUILD=1
-
-"%PYTHON%" setup.py build_ext --tiledb=%LIBRARY_PREFIX% ^
-           install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1
+set "TILEDB_PATH=%LIBRARY_PREFIX%" && %PYTHON% -m pip install --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/build.sh b/recipe/build.sh
index 157dbd6..273377b [10](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10061640917/job/27812196459#step:12:11)0644
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1 @@
-#!/bin/bash
-
-set -e
-set -x
-
-export TILEDB_CONDA_BUILD=1
-
-$PYTHON setup.py install --tiledb="$PREFIX" --single-version-externally-managed --record record.txt
+TILEDB_PATH=${PREFIX} ${PYTHON} -m pip install --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 4a329d6..59e9156 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,15 @@
-{% set name = "tiledb" %}
-{% set version = "0.30.2" %}
-{% set sha256 = "8a70e62b1cea6a1bba8afb1d36a635e9c5435db733944fb4e6d7493fa1d914a3" %}
-
+# nightly build
 package:
   name: tiledb-py
-  version: {{ version }}
+  version: 0.30.2.2024_07_23
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-
+  git_url: https://github.com/TileDB-Inc/TileDB-Py.git
+  git_rev: c506394827ae8eadd7ad021dd007022406516c19
+  git_depth: -1
 build:
   number: 0
   skip: true  # [win32]
-  skip: true  # [win and py2k]
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -24,6 +19,8 @@ requirements:
     - cython <3.0                            # [build_platform != target_platform]
     - numpy                                  # [build_platform != target_platform]
     - pybind[11](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10061640917/job/27812196459#step:12:12)                               # [build_platform != target_platform]
+    - make
+    - cmake
   host:
     - pip
     - wheel
@@ -33,7 +30,8 @@ requirements:
     - cython <3.0
     - numpy
     - pybind11
-    - tiledb >=2.24.0,<2.25
+    - tiledb *.2024_07_23
+    - scikit-build-core
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -62,7 +60,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Python interface to the TileDB sparse and dense multi-dimensional array storage manager
+  summary: Python interface to the TileDB sparse and dense multi-dimensional array
+    storage manager
   description: |
     TileDB-Py is the python interface to the TileDB array storage manager.
     TileDB  is an efficient multi-dimensional array management system which introduces
```