### PR TITLE
No longer need to delete `script` from tiledb-py-feedstock recipe

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -59,11 +59,6 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb *.%s" % (date)
 
-# Remove `script` field in meta.yaml. It is duplicated for "not win" and "win",
-# and the latter gets deleted during the round-trip of importing and exporting
-# the YAML. For now write to build scripts below
-del updated["build"]["script"]
-
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 


### PR DESCRIPTION
I replaced `script` in `meta.yaml` with separate build scripts in order to make it easier to patch the build commands for the nightly builds. Now I need to remove the lines that previously deleted `script` because now they will throw a missing key error (confirmed locally with `run-local-tiledb-py.sh`)

cc: @dudoslav 
xref: https://github.com/conda-forge/tiledb-py-feedstock/pull/235, #114, #115, #122, #123

I manually triggered a [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10373104224/job/28717423817#step:12:1) to confirm that the build scripts are still properly overwritten:

```diff
diff --git a/recipe/bld.bat b/recipe/bld.bat
index fa0b28a..c354431 100644
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1 @@
-@echo on
-
-set TILEDB_PATH=%LIBRARY_PREFIX%
-
-%PYTHON% -m pip install --no-build-isolation --no-deps --ignore-installed -v .
-if errorlevel 1 exit 1
+set "TILEDB_PATH=%LIBRARY_PREFIX%" && %PYTHON% -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/build.sh b/recipe/build.sh
index 0c71530..3adfd1b 100644
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1 @@
-#!/bin/bash
-set -eux
-
-TILEDB_PATH=${PREFIX}
-
-$PYTHON -m pip install --no-build-isolation --no-deps --ignore-installed -v .
+TILEDB_PATH=${PREFIX} ${PYTHON} -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF --no-build-isolation --no-deps --ignore-installed -v .
\ No newline at end of file
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 3fbef98..0afe1dc 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,12 @@
-{% set name = "tiledb" %}
-{% set version = "0.31.1" %}
-{% set sha256 = "7b9ddd32c4c7437111764645d8a042d603102a813c8b89addaf9a15bd40dd939" %}
-
+# nightly build
 package:
   name: tiledb-py
-  version: {{ version }}
+  version: 0.31.0.2024_08_13
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-
+  git_url: https://github.com/TileDB-Inc/TileDB-Py.git
+  git_rev: 2ef0bb93da61f49ad46d4547a8650c2fd04f0adc
+  git_depth: -1
 build:
   number: 0
 requirements:
@@ -34,7 +30,7 @@ requirements:
     - cython >=3.0
     - numpy
     - pybind11
-    - tiledb >=2.25.0,<2.26
+    - tiledb *.2024_08_13
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -63,7 +59,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Python interface to the TileDB sparse and dense multi-dimensional array storage manager
+  summary: Python interface to the TileDB sparse and dense multi-dimensional array
+    storage manager
   description: |
     TileDB-Py is the python interface to the TileDB array storage manager.
     TileDB  is an efficient multi-dimensional array management system which introduces
```