### PR TITLE
Delete old nightlies every day

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -1,7 +1,7 @@
 name: Delete old nightlies
 on:
   schedule:
-     - cron: "36 0 * * 1" # Every Monday
+     - cron: "36 0 * * *" # Every day
   workflow_dispatch:
     inputs:
       TILEDB_CI_ACCOUNT:


### PR DESCRIPTION
**Motivation:** to free up storage space on anaconda.org by reducing the number of nightly binaries stored at any one time

Currently the pipeline to delete old nightlies more than 7 days old only runs on Monday. Thus at the beginning of the week, there are only 7 days worth of nightlies stored on anaconda.org. However, by Sunday there are 14 days worth. This PR increases the frequency to daily so that there is consistently only 7 days worth of nightlies stored at once.