### PR TITLE
Only build oldest and newest Python variants for nightly builds

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -5,6 +5,7 @@
 # Reads values for version, date, and commit from plain-text files
 
 recipe = "tiledb-py-feedstock/recipe/meta.yaml"
+conda_build_config = "tiledb-py-feedstock/recipe/conda_build_config.yaml"
 
 from ruamel.yaml import YAML
 from yaml.constructor import ConstructorError
@@ -81,3 +82,21 @@ with open("tiledb-py-feedstock/recipe/bld.bat", "w") as f:
         f"-Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS={remove_deprecations_value} "
         "--no-build-isolation --no-deps --ignore-installed -v ."
     )
+
+# Update conda build config ---------------------------------------------------
+
+with open(conda_build_config) as f:
+    config = yaml.load(f)
+
+# Limit CI and storage requirements by only building the oldest and newest
+# Python versions supported by conda-forge. Will need to be occasionally updated
+# as old Python versions are dropped and new ones are added
+#
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+
+config["python"] = ["3.8.* *_cpython", "3.12.* *_cpython"]
+config["python_impl"] = ["cpython", "cpython"]
+config["numpy"] = [1.22, 1.26]
+
+with open(conda_build_config, "w") as f:
+    yaml.dump(config, f)


### PR DESCRIPTION
In an effort to reduce both the CI and storage required for the nightly feedstock builds, I updated the tiledb-py-feedstock to only build the oldest and newest Python versions supported by conda-forge, currently 3.8 and 3.12, respectively.

I confirmed this works locally as well as in a manual run, which showed the [CI files for 3.9, 3.10, and 3.11 being deleted](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10564818555/job/29268043740#step:15:33).

Note that this will require the occasional manual maintenance as the conda-forge global pin for Python/numpy are updated. This PR is based on https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/5ccbd396dc675580aff241f5b313e4b00a2ad9d6/recipe/conda_build_config.yaml#L764