### PR TITLE
No longer need to manually remove lz4 patch for 2.26

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,9 +23,5 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
-# (temporary) Remove lz4-fix.patch
-git -C tiledb-feedstock/ rm recipe/lz4-fix.patch
-sed -i /lz4-fix.patch/d tiledb-feedstock/recipe/meta.yaml
-
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/


### PR DESCRIPTION
Closes #111

The recently released TileDB 2.26 no longer includes the lz4 patch in its feedstock recipe

xref: https://github.com/conda-forge/tiledb-feedstock/issues/315, https://github.com/conda-forge/tiledb-feedstock/pull/344