### PR TITLE
Fix tiledb-py-feedstock setup job after migration to numpy 2

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -7,6 +7,7 @@
 recipe = "tiledb-py-feedstock/recipe/meta.yaml"
 conda_build_config = "tiledb-py-feedstock/recipe/conda_build_config.yaml"
 
+import os
 from ruamel.yaml import YAML
 from yaml.constructor import ConstructorError
 from yaml.scanner import ScannerError
@@ -77,7 +78,7 @@ with open("tiledb-py-feedstock/recipe/build.sh", "w") as f:
 
 with open("tiledb-py-feedstock/recipe/bld.bat", "w") as f:
     f.write(
-        f"set \"TILEDB_PATH=%LIBRARY_PREFIX%\" "
+        f'set "TILEDB_PATH=%LIBRARY_PREFIX%" '
         "&& %PYTHON% -m pip install "
         f"-Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS={remove_deprecations_value} "
         "--no-build-isolation --no-deps --ignore-installed -v ."
@@ -100,3 +101,9 @@ config["numpy"] = ["2.0", "2.0"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)
+
+# Have to remove numpy2 migration file to rerender with subset of Python
+# variants
+numpy2_migration = "tiledb-py-feedstock/.ci_support/migrations/numpy2.yaml"
+if os.path.isfile(numpy2_migration):
+    os.remove(numpy2_migration)

--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -94,9 +94,9 @@ with open(conda_build_config) as f:
 #
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
-config["python"] = ["3.8.* *_cpython", "3.12.* *_cpython"]
+config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
-config["numpy"] = [1.22, 1.26]
+config["numpy"] = ["2.0", "2.0"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)


### PR DESCRIPTION
Closes #140 

The recently merged https://github.com/conda-forge/tiledb-py-feedstock/pull/238 bumped tiledb-py-feedstock to 0.32.0, dropped the py38 variant, and migrated to numpy 2. This PR updates the subset of Python and numpy variants for the nightly builds, and also deletes the numpy2 migration file if it exists, since it breaks the rerendering when using a subset in `conda_build_config.yaml`.

xref: #132

Successful test run in https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/10865136719/job/30151246441