### PR TITLE
Always remove deprecations when building tiledb-py

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -64,8 +64,7 @@ for i in range(len(updated["requirements"]["host"])):
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 
-# Run with deprecation warnings on Mondays for forward-looking alerts.
-remove_deprecations_value = "ON" if datetime.today().weekday() == 0 else "OFF"
+remove_deprecations_value = "ON"
 
 # Create OS-specific build scripts
 with open("tiledb-py-feedstock/recipe/build.sh", "w") as f:


### PR DESCRIPTION
In https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/122, deprecations were set to be removed only on Mondays. However, this no longer seems necessary, as we aim to catch early issues, such as https://github.com/TileDB-Inc/TileDB-Py/pull/2111#issuecomment-2483966610.

This PR updates the recipe to always remove deprecations.