### PR TITLE
Never remove deprecations when building tiledb-py

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -64,8 +64,8 @@ for i in range(len(updated["requirements"]["host"])):
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 
-# Run with deprecation warnings on Mondays for forward-looking alerts.
-remove_deprecations_value = "ON" if datetime.today().weekday() == 0 else "OFF"
+# Run without deprecation warnings
+remove_deprecations_value = "OFF"
 
 # Create OS-specific build scripts
 with open("tiledb-py-feedstock/recipe/build.sh", "w") as f:


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/152, it appears that our nightlies now contain only noise. After discussing with @ihnorton, we decided to set `TILEDB_REMOVE_DEPRECATIONS` to `OFF`, as was done in TileDB-Py https://github.com/TileDB-Inc/TileDB-Py/pull/2112. Checks for the use of deprecations will be conducted manually on a regular basis.