### PR TITLE
Replace py312 with py313 for build with latest Python variant

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -95,15 +95,18 @@ with open(conda_build_config) as f:
 #
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
-config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
+config["python"] = ["3.9.* *_cpython", "3.13.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
 config["numpy"] = ["2.0", "2.0"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)
 
-# Have to remove numpy2 migration file to rerender with subset of Python
-# variants
+# Have to remove python313/numpy2 migration files to rerender with subset of
+# Python variants
+python313_migration = "tiledb-py-feedstock/.ci_support/migrations/python313.yaml"
+if os.path.isfile(python313_migration):
+    os.remove(python313_migration)
 numpy2_migration = "tiledb-py-feedstock/.ci_support/migrations/numpy2.yaml"
 if os.path.isfile(numpy2_migration):
     os.remove(numpy2_migration)


### PR DESCRIPTION
When investigating #151, I noticed that there are now 3 Python variants being tested in the nightly builds: py39, py312, and py313. This is because tiledb-py-feedstock was recently migrated to py313 in https://github.com/conda-forge/tiledb-py-feedstock/pull/246. Even though our nightly scripts request only py39 and py312, since the migration file exists, the [rerendering](https://github.com/TileDB-Inc/tiledb-py-feedstock/commit/258fff9165133ef292fc55951f3a94c8db332580) keeps the py313 build.

Following the strategy I started in #132, this PR updates the nightly feedstock builds to only test with py39 and py313.

Here is a [manual run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12123294573/job/33798449382) of my internal branch that demonstrates that with this PR the py312 build is dropped.