### PR TITLE
Allow py313 to be a third Python build

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -95,7 +95,7 @@ with open(conda_build_config) as f:
 #
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
-config["python"] = ["3.9.* *_cpython", "3.13.* *_cp313"]
+config["python"] = ["3.9.* *_cpython", "3.13.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
 config["numpy"] = ["2.0", "2.0"]
 

--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -95,18 +95,15 @@ with open(conda_build_config) as f:
 #
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
-config["python"] = ["3.9.* *_cpython", "3.13.* *_cpython"]
+config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
 config["numpy"] = ["2.0", "2.0"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)
 
-# Have to remove python313/numpy2 migration files to rerender with subset of
-# Python variants
-python313_migration = "tiledb-py-feedstock/.ci_support/migrations/python313.yaml"
-if os.path.isfile(python313_migration):
-    os.remove(python313_migration)
+# Have to remove numpy2 migration file to rerender with subset of Python
+# variants
 numpy2_migration = "tiledb-py-feedstock/.ci_support/migrations/numpy2.yaml"
 if os.path.isfile(numpy2_migration):
     os.remove(numpy2_migration)


### PR DESCRIPTION
This PR undoes my recent PRs #154 and #155. My goal was to reduce the CI resources by only building two versions of Python instead of 3. However, trying to manually build only py39 and py313 has proved challenging, and I've determined it's not worth the effort to continue troubleshooting. Once the [py313 conda-forge migration](https://conda-forge.org/status/migration/?name=python313) has finished, then I'll update this repo.

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/151#issuecomment-2517953846

Example run that demonstrates that only the CI files for py310 and py311 are deleted: https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12164471665/job/33926203028#step:15:31