### PR TITLE
Install latest tiledb from tiledb/label/nightlies (support mamba 2)

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -59,7 +59,7 @@ updated["build"]["number"] = 0
 # Pin tiledb by the date
 for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
-        updated["requirements"]["host"][i] = "tiledb *.%s" % (date)
+        updated["requirements"]["host"][i] = "tiledb"
 
 with open(recipe, "w") as f:
     yaml.dump(updated, f)


### PR DESCRIPTION
Frustratingly mamba 2 only supports trailing globs for version specifications (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/151#issuecomment-2514886465, https://github.com/mamba-org/mamba/issues/3601#issuecomment-2518353107), thus we can no longer use `tiledb *.YYYY_MM_DD` to force the installation of the latest nightly binary.

There is an upside though. This will always install the latest available from `tiledb/label/nightlies`, so even if the tiledb-feedstock nightly fails, we can still test tiledb-py-feedstock with the latest TileDB-Py against the most recently available tiledb nightly conda binary.

Example run: https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12284772346/job/34281301031#step:12:87

```diff
-    - tiledb >=2.26.0,<2.27
+    - tiledb
```