### PR TITLE
Specify latest tiledb using the pin 2.*

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -59,7 +59,7 @@ updated["build"]["number"] = 0
 # Pin tiledb by the date
 for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
-        updated["requirements"]["host"][i] = "tiledb"
+        updated["requirements"]["host"][i] = "tiledb 2.*"
 
 with open(recipe, "w") as f:
     yaml.dump(updated, f)


### PR DESCRIPTION
Follow-up to #157 

**Diagnosis:** That PR updated the tiledb requirement to be `tiledb`. However, that had the unforeseen consequence of then using the conda-forge global pin in `.ci_support/`, which is currently 2.26 (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/151#issuecomment-2540015895).

**Solution:** Mamba 2 can properly handle trailing globs in version specifications. Thus I updated the script to replace the tiledb requirement with `tiledb 2.*`. This means we won't have to update it if/until we release a 3.0.

**Demonstration:**
* Using `tiledb 2.*` in the nightly-build on my [fork](https://github.com/jdblischak/tiledb-py-feedstock/commit/194245b52e3aec4722c872a8288ead29e49b3d8b) properly installed the nightly tiledb `2.27.0.2024_12_12`. The jobs ultimately failed at the upload step only because I have registered my personal Anaconda token in my fork, and thus this token is unable to upload to the tiledb channel
* Manual [job](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12319481661/job/34386627122#step:12:87) using this PR's branch properly updated the tiledb requirement
```diff
-    - tiledb >=2.26.0,<2.27
+    - tiledb 2.*
```
