### PR TITLE
Define new zip key is_python_min when limiting python variants

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -98,6 +98,7 @@ with open(conda_build_config) as f:
 config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
 config["numpy"] = ["2.0", "2.0"]
+config["is_python_min"] = ["true", "false"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)


### PR DESCRIPTION
Closes #162 

Successful build on my branch (https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12657342326/job/35271878617):
* The key `is_python_min` was added to `conda_build_config.yaml` (it adds `'true'` and `'false'` instead of `true` and `false`, but I don't think this matters) (https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12657342326/job/35271878617#step:12:53)
* And the successful rerendering deleted the py310 and py311 build variants (https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/12657342326/job/35271878617#step:15:30)
