### PR TITLE
Always upload binaries from branch "nightly-build"

### DIFF
--- a/scripts/update-channels.sh
+++ b/scripts/update-channels.sh
@@ -6,6 +6,11 @@ repo="$1"
 # Disable conda-forge validation
 echo "conda_forge_output_validation: False" >> "$repo/conda-forge.yml"
 
+# Always upload binaries from branch "nightly-build"
+echo "upload_on_branch: nightly-build" >> "$repo/conda-forge.yml"
+# No need to substitute existing value. When a duplicated is duplicated,
+# conda-smithy uses the latest
+
 # Add tiledb as source channel
 echo -e "channel_sources:\n  - tiledb/label/nightlies,conda-forge" >> "$repo/recipe/conda_build_config.yaml"
 


### PR DESCRIPTION
While troubleshooting the tiledb-py-feedstock failures in #167, I realized that no tiledb-py nightly conda binaries have been uploaded in at least a week (since we delete any older than 7 days).

https://anaconda.org/tiledb/tiledb-py/files

Looking at last night's Azure build [log](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=41871&view=results), it says "The branch nightly-build is not configured to be uploaded"

I was initially puzzled since we haven't made any related modifications recently to hte tiledb-py-feedstock nightly builds, but I eventually figured it out. Two months ago I added `upload_on_branch: main` to tiledb-py-feedstock to prevent accidental uploads from internal branches (https://github.com/conda-forge/tiledb-py-feedstock/pull/250).

The fix is straightforward. I don't even need to substitute the existing value of `upload_on_branch`. I confirmed locally that `conda-smithy` will just use the latest value. I also manually triggered a [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/13294286917) from this branch.