### PR TITLE
Update nightly tiledb-py-feedstock now that np2 migration has closed

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -97,14 +97,7 @@ with open(conda_build_config) as f:
 
 config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
 config["python_impl"] = ["cpython", "cpython"]
-config["numpy"] = ["2.0", "2.0"]
 config["is_python_min"] = ["true", "false"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)
-
-# Have to remove numpy2 migration file to rerender with subset of Python
-# variants
-numpy2_migration = "tiledb-py-feedstock/.ci_support/migrations/numpy2.yaml"
-if os.path.isfile(numpy2_migration):
-    os.remove(numpy2_migration)


### PR DESCRIPTION
Closes #187

The numpy 2 migration was closed on Friday (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7461). This also removed `numpy` from the Python-related zip keys.

This PR fixes the broken py313 nightly tiledb-py-feedstock builds by removing `numpy` from `conda_build_config.yaml`.

* I manually triggered this PR branch to confirm there are no setup problems ([run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/15537291730))
* I locally ran `bash run-local-tiledb-py.sh` and pushed the result to my fork ([nightly-build-np2](https://github.com/jdblischak/tiledb-py-feedstock/tree/nightly-build-np2)) to confirm the py313 builds [passed](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=1285&view=results)

The main difference is that the failing build pinned numpy [`'2.0'`](https://github.com/TileDB-Inc/tiledb-py-feedstock/blob/5aea468495ffa3db52f18d2aea4114527d88552a/.ci_support/linux_64_python3.13.____cp313.yaml#L18) whereas the passing build pinned numpy [`'2'`](https://github.com/jdblischak/tiledb-py-feedstock/blob/caff6a93c21f5424e76408ee2f1af7cc81f6e9bc/.ci_support/linux_64_python3.13.____cp313.yaml#L18). This only affected the py313 build because numpy 2.0 is not available for py313.