### PR TITLE
Remove python_impl from Python-related zip keys

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -96,7 +96,6 @@ with open(conda_build_config) as f:
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
 config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
-config["python_impl"] = ["cpython", "cpython"]
 config["is_python_min"] = ["true", "false"]
 
 with open(conda_build_config, "w") as f:


### PR DESCRIPTION
The field `python_impl` was also removed from the Python-related zip keys (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7474). This happened 3 days ago (https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/be2ab14d09b61657d873852a567afdc340d468a4), and interestingly didn't break our feedstock rerendering.

I confirmed locally that `python_impl` can be safely removed from `recipe/conda_build_config.yaml` without affecting `conda smithy rerender`. I also triggered a [manual run of this PR branch](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/15716005997).