### PR TITLE
Pin pybind11 <3 for nightly tiledb-py-feedstock builds

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -61,6 +61,14 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb 2.*"
 
+# (temporary) pin pybind11 <3
+for i in range(len(updated["requirements"]["host"])):
+    if updated["requirements"]["host"][i].startswith("pybind11"):
+        updated["requirements"]["host"][i] = "pybind11 <3"
+for i in range(len(updated["requirements"]["build"])):
+    if updated["requirements"]["build"][i].startswith("pybind11"):
+        updated["requirements"]["build"][i] = "pybind11 <3"
+
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 


### PR DESCRIPTION
Closes #194 

xref: TileDB-Inc/TileDB-Py#2215, https://github.com/conda-forge/tiledb-py-feedstock/pull/262

Running into problems applying this change upstream. It does appear to fix the nightly feedstock builds though ([example](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=1312&view=results)).