### PR TITLE
Build all Python versions for debugging

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -103,8 +103,9 @@ with open(conda_build_config) as f:
 #
 # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 
-config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
-config["is_python_min"] = ["true", "false"]
+# (temporary) Skip this step to build all Python versions for debugging
+# config["python"] = ["3.9.* *_cpython", "3.12.* *_cpython"]
+# config["is_python_min"] = ["true", "false"]
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)


### PR DESCRIPTION
We have observed some Python-version-specific test failures in the nightly feedstock builds. This PR temporarily re-enables building all Python variants to facilitate debugging

xref: #194, #195, https://github.com/TileDB-Inc/TileDB-Py/pull/2215, https://github.com/conda-forge/tiledb-py-feedstock/pull/262#issuecomment-3080000576

* Test [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/16347016028) of this PR