### PR TITLE
Revert "Pin pybind11 <3 for nightly tiledb-py-feedstock builds (#195)"

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -61,14 +61,6 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb 2.*"
 
-# (temporary) pin pybind11 <3
-for i in range(len(updated["requirements"]["host"])):
-    if updated["requirements"]["host"][i].startswith("pybind11"):
-        updated["requirements"]["host"][i] = "pybind11 <3"
-for i in range(len(updated["requirements"]["build"])):
-    if updated["requirements"]["build"][i].startswith("pybind11"):
-        updated["requirements"]["build"][i] = "pybind11 <3"
-
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 


### PR DESCRIPTION
This reverts commit f1ed56dd2536b96a1d58f4e46a8c7b36e3eb6baf.

Undo https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/195 now that https://github.com/conda-forge/tiledb-py-feedstock/pull/266 was merged upstream

manual test run: https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/16455924208