### PR TITLE
Update bash flags for default shell so that errors fail the workflow

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -23,7 +23,7 @@ on:
         default: 0
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0}
 env:
   TILEDB_CI_ACCOUNT: ${{ github.event.inputs.TILEDB_CI_ACCOUNT || 'tiledb' }}
   TILEDB_CI_DAYS: ${{ github.event.inputs.TILEDB_CI_DAYS || 7 }}

--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -51,17 +51,17 @@ jobs:
             wheel
           cache-environment: true
       - name: Update conda-smithy
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: micromamba update --yes conda-smithy
       - name: Obtain version
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: bash ci/scripts/tiledb-py/obtain-version.sh
       - name: Obtain commit
         run: bash ci/scripts/obtain-commit.sh TileDB-Py
       - name: Pull from upstream feedstock
         run: bash ci/scripts/pull-upstream-feedstock.sh tiledb-py-feedstock
       - name: Update recipe
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: python ci/scripts/tiledb-py/update-recipe.py
       - name: Print recipe diff
         run: git -C tiledb-py-feedstock/ --no-pager diff recipe/
@@ -70,7 +70,7 @@ jobs:
       - name: Add and commit
         run: bash ci/scripts/add-and-commit.sh tiledb-py-feedstock
       - name: Rerender feedstock
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: bash ci/scripts/rerender-feedstock.sh tiledb-py-feedstock
       - name: Push update to GitHub
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -49,10 +49,10 @@ jobs:
           create-args: conda-smithy jsonschema
           cache-environment: true
       - name: Update conda-smithy
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: micromamba update --yes conda-smithy
       - name: Rerender feedstock
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: bash ci/scripts/rerender-feedstock.sh tiledb-feedstock
       - name: Push update to GitHub
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'


### PR DESCRIPTION
https://github.com/mamba-org/setup-micromamba/tree/v1/#about-login-shells

xref: #205, https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/334

We ran out of storage space on anaconda.org because the workflow [delete-old-nightlies.yml](https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/main/.github/workflows/delete-old-nightlies.yml) has been silently failing for about two months (every nightly since version [2.29.0.2025_07_14](https://anaconda.org/tiledb/tiledb/files?channel=nightlies&version=2.29.0.2025_07_14) still exists).

https://anaconda.org/tiledb/tiledb/files?channel=nightlies
https://anaconda.org/tiledb/tiledb-py/files?channel=nightlies

This PR the default bash flags to properly fail on error. Here is a [test run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/17679018580) using this PR branch that properly fails due to the expired token:

```
Error:  ('Authentication token has expired', 401)
```