### PR TITLE
Use default shell in all workflows

### DIFF
--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -5,6 +5,9 @@ on:
   schedule:
      - cron: "0 3 * * *" # Every night at 3 AM UTC (10 PM EST; 11 PM EDT)
   workflow_dispatch:
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
 jobs:
   tiledb-py:
     runs-on: ubuntu-latest
@@ -51,17 +54,14 @@ jobs:
             wheel
           cache-environment: true
       - name: Update conda-smithy
-        shell: bash -leo pipefail {0}
         run: micromamba update --yes conda-smithy
       - name: Obtain version
-        shell: bash -leo pipefail {0}
         run: bash ci/scripts/tiledb-py/obtain-version.sh
       - name: Obtain commit
         run: bash ci/scripts/obtain-commit.sh TileDB-Py
       - name: Pull from upstream feedstock
         run: bash ci/scripts/pull-upstream-feedstock.sh tiledb-py-feedstock
       - name: Update recipe
-        shell: bash -leo pipefail {0}
         run: python ci/scripts/tiledb-py/update-recipe.py
       - name: Print recipe diff
         run: git -C tiledb-py-feedstock/ --no-pager diff recipe/
@@ -70,7 +70,6 @@ jobs:
       - name: Add and commit
         run: bash ci/scripts/add-and-commit.sh tiledb-py-feedstock
       - name: Rerender feedstock
-        shell: bash -leo pipefail {0}
         run: bash ci/scripts/rerender-feedstock.sh tiledb-py-feedstock
       - name: Push update to GitHub
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -3,6 +3,9 @@ on:
   schedule:
      - cron: "0 1 * * *" # Every night at 1 AM UTC (8 PM EST; 9 PM EDT)
   workflow_dispatch:
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
 jobs:
   tiledb:
     runs-on: ubuntu-latest
@@ -49,10 +52,8 @@ jobs:
           create-args: conda-smithy jsonschema
           cache-environment: true
       - name: Update conda-smithy
-        shell: bash -leo pipefail {0}
         run: micromamba update --yes conda-smithy
       - name: Rerender feedstock
-        shell: bash -leo pipefail {0}
         run: bash ci/scripts/rerender-feedstock.sh tiledb-feedstock
       - name: Push update to GitHub
         if: github.ref == 'refs/heads/main' && github.repository_owner == 'TileDB-Inc' && github.event_name != 'pull_request'


### PR DESCRIPTION
Follow-up to #206

I realized that it would be cleaner to use the default login shell for all steps, even if some don't require the conda environment. The only real difference this will make is that the push to GitHub will use the `git` installed in the conda environment instead of the default version installed on the GitHub Actions runner, which I don't anticipate will matter.