### PR TITLE
Add azure-storage-files-datalake-cpp to nightly tiledb-feedstock build

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,9 +23,16 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
-# (temporary) Remove TILEDB_HDFS
-sed -i '/TILEDB_HDFS/d' tiledb-feedstock/recipe/bld.bat
-sed -i '/TILEDB_HDFS/d' tiledb-feedstock/recipe/build.sh
+# (temporary) Add azure-storage-files-datalake-cpp
+mkdir -p tiledb-feedstock/recipe/tiledb-patches/system-ports/azure-storage-files-datalake-cpp
+echo "set(VCPKG_POLICY_EMPTY_PACKAGE enabled)" \
+  > tiledb-feedstock/recipe/tiledb-patches/system-ports/azure-storage-files-datalake-cpp/portfile.cmake
+echo '{ "name": "azure-storage-files-datalake-cpp", "version-string": "system" }' \
+  > tiledb-feedstock/recipe/tiledb-patches/system-ports/azure-storage-files-datalake-cpp/vcpkg.json
+
+sed -i \
+  s/host:/'host:\n    - azure-storage-files-datalake-cpp'/ \
+  tiledb-feedstock/recipe/meta.yaml
 
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/


### PR DESCRIPTION
Close #212 

xref: #71, https://github.com/TileDB-Inc/TileDB/pull/5652

Manual [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/18224258959) from this branch looks good. Also ran locally with `run-local-tiledb.sh`