### PR TITLE
Delete py314 migration for nightly tiledb-py-feedstock builds

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -101,3 +101,10 @@ with open(conda_build_config) as f:
 
 with open(conda_build_config, "w") as f:
     yaml.dump(config, f)
+
+# (temporary) Delete py314 migration file. It added `channel_sources` to
+# `zip_keys`, which is inconvenient in our nightly setup, and we don't need to
+# test py314 nightly anyways
+python314_migration = "tiledb-py-feedstock/.ci_support/migrations/python314.yaml"
+if os.path.isfile(python314_migration):
+    os.remove(python314_migration)


### PR DESCRIPTION
Closes #215

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/142, https://github.com/conda-forge/tiledb-py-feedstock/pull/272

The py314 migration added `channel_sources` to `zip_keys`, which is inconvenient in our nightly setup, and we don't need to test py314 nightly anyways.

Tested locally with `run-local-tiledb-py.sh` and in [manual CI run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/18351151028)