### PR TITLE
Remove azure patch and add new requirement c-blosc2

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,5 +23,22 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
+# (temporary) Remove azure patch
+git -C tiledb-feedstock/ rm recipe/azure-fix.patch
+sed -i \
+  -e '/patches/d' -e '/azure-fix.patch/d' \
+  tiledb-feedstock/recipe/meta.yaml
+
+# (temporary) Add c-blosc2
+mkdir -p tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2
+echo "set(VCPKG_POLICY_EMPTY_PACKAGE enabled)" \
+  > tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2/portfile.cmake
+echo '{ "name": "blosc2", "version-string": "system" }' \
+  > tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2/vcpkg.json
+
+sed -i \
+  s/host:/'host:\n    - c-blosc2'/ \
+  tiledb-feedstock/recipe/meta.yaml
+
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/


### PR DESCRIPTION
Closes #223

This PR makes two temporary changes to the nightly tiledb-feedstock build to accommodate recent upstream changes until the next release.

* azure patch is no longer needed after vcpkg baseline was updated (https://github.com/TileDB-Inc/TileDB/pull/5616)
* New requirement c-blosc2 was added (https://github.com/TileDB-Inc/TileDB/pull/5620)

cc: @teo-tsirpanis 