### PR TITLE
Remove py314 patch that has been merged upstream but not yet released

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -61,6 +61,10 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb 2.*"
 
+# (temporary) Remove py314 patch that has been merged upstream but not yet
+# released
+del updated["source"]["patches"]
+
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 


### PR DESCRIPTION
The patch I added to support Python 3.14 in https://github.com/conda-forge/tiledb-py-feedstock/pull/272 has been merged upstream (https://github.com/TileDB-Inc/TileDB-Py/pull/2256)

cc: @kounelisagis 