### PR TITLE
No longer attempt to remove patch that has been removed from feedstock

### DIFF
--- a/scripts/tiledb-py/update-recipe.py
+++ b/scripts/tiledb-py/update-recipe.py
@@ -61,10 +61,6 @@ for i in range(len(updated["requirements"]["host"])):
     if updated["requirements"]["host"][i].startswith("tiledb"):
         updated["requirements"]["host"][i] = "tiledb 2.*"
 
-# (temporary) Remove py314 patch that has been merged upstream but not yet
-# released
-del updated["source"]["patches"]
-
 with open(recipe, "w") as f:
     yaml.dump(updated, f)
 


### PR DESCRIPTION
Closes #227 

The TileDB-Py setup job starting failing on Friday night because I merged the TileDB-Py 0.35.2 update PR to tiledb-py-feedstock earlier that day. This temporary code is no longer needed since I removed the patch in https://github.com/conda-forge/tiledb-py-feedstock/commit/5101e7875d6034705d5b313750b02d74951c637f

xref: #225, https://github.com/conda-forge/tiledb-py-feedstock/pull/275

Manual [run](https://github.com/TileDB-Inc/conda-forge-nightly-controller/actions/runs/19242338918) was successful.