### PR TITLE
Remove workarounds now that TileDB 2.30.0 has been released

### DIFF
--- a/scripts/tiledb/update-recipe.sh
+++ b/scripts/tiledb/update-recipe.sh
@@ -23,22 +23,5 @@ sed -i \
   s/"  number: [0-9]\+"/"  number: 0"/ \
   tiledb-feedstock/recipe/meta.yaml
 
-# (temporary) Remove azure patch
-git -C tiledb-feedstock/ rm recipe/azure-fix.patch
-sed -i \
-  -e '/patches/d' -e '/azure-fix.patch/d' \
-  tiledb-feedstock/recipe/meta.yaml
-
-# (temporary) Add c-blosc2
-mkdir -p tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2
-echo "set(VCPKG_POLICY_EMPTY_PACKAGE enabled)" \
-  > tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2/portfile.cmake
-echo '{ "name": "blosc2", "version-string": "system" }' \
-  > tiledb-feedstock/recipe/tiledb-patches/system-ports/blosc2/vcpkg.json
-
-sed -i \
-  s/host:/'host:\n    - c-blosc2'/ \
-  tiledb-feedstock/recipe/meta.yaml
-
 # Print differences
 git -C tiledb-feedstock/ --no-pager diff recipe/


### PR DESCRIPTION
Closes #232 

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/224, https://github.com/conda-forge/tiledb-feedstock/pull/470