### PR TITLE
Reduce nightly feedstock build frequency to once per week

### DIFF
--- a/.github/workflows/check-azure-status.yml
+++ b/.github/workflows/check-azure-status.yml
@@ -4,8 +4,9 @@
 name: check-azure-status
 on:
   schedule:
-     # https://crontab.guru/#0_11_*_*_*
-     - cron: "0 11 * * *" # Every day at 11 AM UTC (6 AM EST; 7 AM EDT)
+     # Every Monday at 11 AM UTC (6 AM EST; 7 AM EDT)
+     # https://crontab.guru/#0_11_*_*_1
+     - cron: "0 11 * * 1"
   workflow_dispatch:
 jobs:
   tiledb-feedstock:

--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -1,7 +1,9 @@
 name: Delete old nightlies
 on:
   schedule:
-     - cron: "36 0 * * *" # Every day
+    # Every Wednesday at 12:36 AM UTC (Tuesday at 7:36 PM EST; 8:36 PM EDT)
+    # https://crontab.guru/#36_0_*_*_3
+     - cron: "36 0 * * 3"
   workflow_dispatch:
     inputs:
       TILEDB_CI_ACCOUNT:

--- a/.github/workflows/tiledb-py.yml
+++ b/.github/workflows/tiledb-py.yml
@@ -3,7 +3,9 @@ on:
   # This job depends on a previous passing run of TileDB conda nightly.
   # Schedule for conda nightly against TileDB-Py should begin after TileDB core.
   schedule:
-     - cron: "0 3 * * *" # Every night at 3 AM UTC (10 PM EST; 11 PM EDT)
+    # Every Monday at 3 AM UTC (Sunday at 10 PM EST; 11 PM EDT)
+    # https://crontab.guru/#0_3_*_*_1
+     - cron: "0 3 * * 1"
   workflow_dispatch:
 defaults:
   run:

--- a/.github/workflows/tiledb.yml
+++ b/.github/workflows/tiledb.yml
@@ -1,7 +1,9 @@
 name: tiledb
 on:
   schedule:
-     - cron: "0 1 * * *" # Every night at 1 AM UTC (8 PM EST; 9 PM EDT)
+     # Every Monday at 1 AM UTC (Sunday at 8 PM EST; 9 PM EDT)
+     # https://crontab.guru/#0_1_*_*_1
+     - cron: "0 1 * * 1"
   workflow_dispatch:
 defaults:
   run:


### PR DESCRIPTION
xref: https://github.com/TileDB-Inc/centralized-tiledb-nightlies/commit/af71837a63cf3f5aa7144e6f1ee1058164f97dc3